### PR TITLE
HotFix

### DIFF
--- a/src/components/document/VersionModal.vue
+++ b/src/components/document/VersionModal.vue
@@ -24,6 +24,23 @@
                             </v-btn>
                         </template>
                     </v-tooltip>
+                    <v-tooltip 
+                        v-else
+                        text="release status" 
+                        location="bottom">
+                        <template v-slot:activator="{ props: tooltip }">
+                            <v-btn 
+                                :disabled="true" 
+                                variant="tonal" 
+                                density="compact" 
+                                v-bind="tooltip" 
+                                :color="$store.state.selected.data?.releasedVersion?.length > 0 ? undefined : 'orange'" 
+                                :text-color="$store.state.selected.data?.releasedVersion?.length > 0 ? undefined : 'white'" 
+                                class="mx-1 mr-0 text-none rounded-s-pill" >
+                                {{ $store.state.selected.data?.releasedVersion?.length > 0 ? 'Released' : 'Staged' }}
+                            </v-btn>
+                        </template>
+                    </v-tooltip>
                     <v-tooltip text="switch version" location="bottom">
                         <template v-slot:activator="{ props: tooltip }">
                             <v-btn 

--- a/src/services/firebaseDataService.js
+++ b/src/services/firebaseDataService.js
@@ -337,7 +337,6 @@ export class Document {
   }
   
   static async getAll(includeArchived = false, includeDraft = false) {
- 
     
     // Check if project.id exists before using it in the query
     if (!store.state.project?.id) {
@@ -356,7 +355,7 @@ export class Document {
     }
 
     if (!store.state.user.uid && !includeDraft) {
-
+      conditions.push(where("draft", "==", false));
     }
 
     const q = query(documentsRef, ...conditions);
@@ -366,6 +365,7 @@ export class Document {
       id: doc.id,
       data: doc.data()
     })));
+
 
     return documents;
   }


### PR DESCRIPTION
+Better handling on version modal, now shows if any docs are released
+Fixed an issue where switching between versions was saving over docs
+implemented a utility to sync draft state and released versions with subCollection (not the best way to do it but it does protect against backwards compatibility issues, and shouldnt introduce too many writes) 